### PR TITLE
Feat: 댓글, 대댓글 CRUD 구현

### DIFF
--- a/src/api/comments/comments.ts
+++ b/src/api/comments/comments.ts
@@ -1,0 +1,51 @@
+import { CommentProps } from "@/lib/comments/types";
+
+const API_URL = "/api/comments";
+
+export const commentApi = {
+  getComments: async (postId: string): Promise<CommentProps[]> => {
+    const response = await fetch(`${API_URL}?postId=${postId}`);
+    if (!response.ok) {
+      throw new Error("Failed to fetch comments");
+    }
+    return response.json();
+  },
+
+  addComment: async (
+    comment: Omit<CommentProps, "id" | "timestamp" | "replies">
+  ): Promise<CommentProps> => {
+    const response = await fetch(API_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(comment),
+    });
+    if (!response.ok) {
+      throw new Error("Failed to add comment");
+    }
+    return response.json();
+  },
+
+  updateComment: async (id: string, content: string): Promise<void> => {
+    const response = await fetch(API_URL, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ id, content }),
+    });
+    if (!response.ok) {
+      throw new Error("Failed to update comment");
+    }
+  },
+
+  deleteComment: async (id: string): Promise<void> => {
+    const response = await fetch(`${API_URL}?id=${id}`, {
+      method: "DELETE",
+    });
+    if (!response.ok) {
+      throw new Error("Failed to delete comment");
+    }
+  },
+};

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/firebase/firebaseConfig";
+import {
+  collection,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  doc,
+  query,
+  where,
+  getDocs,
+  orderBy,
+  Timestamp,
+} from "firebase/firestore";
+
+const COMMENTS_COLLECTION = "comments";
+
+// 에러 응답 생성 함수
+const createErrorResponse = (message: string, status: number) => {
+  return NextResponse.json({ error: message }, { status });
+};
+
+// 댓글 조회 로직
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const postId = searchParams.get("postId");
+
+  if (!postId) {
+    return createErrorResponse("Post ID is required", 400);
+  }
+
+  try {
+    const commentsRef = collection(db, COMMENTS_COLLECTION);
+    const q = query(
+      commentsRef,
+      where("postId", "==", postId),
+      orderBy("timestamp", "desc")
+    );
+    const querySnapshot = await getDocs(q);
+    const comments = querySnapshot.docs.map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+      timestamp: doc.data().timestamp.toDate().toISOString(),
+    }));
+
+    return NextResponse.json(comments);
+  } catch (error) {
+    console.error("Error fetching comments:", error);
+    return createErrorResponse("Failed to fetch comments", 500);
+  }
+}
+
+// 댓글 작성 로직
+export async function POST(request: NextRequest) {
+  try {
+    const { postId, username, content } = await request.json();
+
+    if (!postId || !username || !content) {
+      return createErrorResponse("Missing required fields", 400);
+    }
+
+    const docRef = await addDoc(collection(db, COMMENTS_COLLECTION), {
+      postId,
+      username,
+      content,
+      timestamp: Timestamp.now(),
+    });
+
+    return NextResponse.json({
+      id: docRef.id,
+      postId,
+      username,
+      content,
+      timestamp: Timestamp.now().toDate().toISOString(),
+    });
+  } catch (error) {
+    console.error("Error adding comment:", error);
+    return createErrorResponse("Failed to add comment", 500);
+  }
+}
+
+// 댓글 수정 로직
+export async function PUT(request: NextRequest) {
+  try {
+    const { id, content } = await request.json();
+
+    if (!id || !content) {
+      return createErrorResponse("Missing required fields", 400);
+    }
+
+    const commentRef = doc(db, COMMENTS_COLLECTION, id);
+    await updateDoc(commentRef, {
+      content,
+      updatedAt: Timestamp.now(),
+    });
+
+    return NextResponse.json({ message: "Comment updated successfully" });
+  } catch (error) {
+    console.error("Error updating comment:", error);
+    return createErrorResponse("Failed to update comment", 500);
+  }
+}
+
+// 댓글 삭제 로직
+export async function DELETE(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get("id");
+
+  if (!id) {
+    return createErrorResponse("Comment ID is required", 400);
+  }
+
+  try {
+    await deleteDoc(doc(db, COMMENTS_COLLECTION, id));
+    return NextResponse.json({ message: "Comment deleted successfully" });
+  } catch (error) {
+    console.error("Error deleting comment:", error);
+    return createErrorResponse("Failed to delete comment", 500);
+  }
+}

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -34,14 +34,14 @@ export async function GET(request: NextRequest) {
     const q = query(
       commentsRef,
       where("postId", "==", postId),
-      orderBy("timestamp", "desc")
+      orderBy("timestamp", "asc")
     );
     const querySnapshot = await getDocs(q);
     const comments = querySnapshot.docs.map((doc) => ({
       id: doc.id,
       ...doc.data(),
       timestamp: doc.data().timestamp.toDate().toISOString(),
-      depth: doc.data().depth || 0, // depth가 없으면 0으로 설정
+      depth: doc.data().depth || 0,
     }));
 
     return NextResponse.json(comments);

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter, useParams } from "next/navigation";
 import { PostContent } from "@/components/posts/PostContent";
-import { CommentsSection } from "@/components/posts/CommentSection";
+import { CommentSection } from "@/components/posts/CommentSection";
 import { usePostStore } from "@/store/posts/postStore";
 import { usePostQuery } from "@/lib/posts/hooks/usePostQuery";
 import { usePostMutations } from "@/lib/posts/hooks/usePostMutations";
@@ -62,7 +62,7 @@ export default function PostDetailPage() {
     <div className="min-h-screen bg-gray-100">
       <main className="py-8">
         <PostContent post={post} onDelete={handleDelete} />
-        <CommentsSection />
+        <CommentSection postId={postId} />
       </main>
     </div>
   );

--- a/src/app/posts/types/index.ts
+++ b/src/app/posts/types/index.ts
@@ -11,14 +11,6 @@ export interface PostResponse {
   id: string;
 }
 
-export interface CommentProps {
-  username: string;
-  content: string;
-  timestamp: string;
-  depth: number;
-  replies?: CommentProps[];
-}
-
 export type ApiError = {
   message: string;
 };

--- a/src/components/common/ui/Button.tsx
+++ b/src/components/common/ui/Button.tsx
@@ -1,3 +1,4 @@
+import { flightRouterStateSchema } from "next/dist/server/app-render/types";
 import React from "react";
 
 export interface ButtonProps {
@@ -8,6 +9,7 @@ export interface ButtonProps {
   fontWeight?: string;
   type?: "button" | "submit" | "reset";
   disabled?: boolean;
+  onClick?: () => void;
 }
 
 export default function Button({
@@ -17,12 +19,16 @@ export default function Button({
   fontSize = "text-sm",
   fontWeight = "font-semibold",
   type = "button",
+  disabled = false,
+  onClick,
 }: ButtonProps) {
   return (
     <div>
       <button
         type={type}
         className={`${width} flex justify-center py-2 px-4 shadow-sm ${rounded} ${fontSize} ${fontWeight} text-font_btn bg-main hover:bg-sub`}
+        onClick={onClick}
+        disabled={disabled}
       >
         {label}
       </button>

--- a/src/components/common/ui/Button.tsx
+++ b/src/components/common/ui/Button.tsx
@@ -1,4 +1,3 @@
-import { flightRouterStateSchema } from "next/dist/server/app-render/types";
 import React from "react";
 
 export interface ButtonProps {

--- a/src/components/posts/Comment.tsx
+++ b/src/components/posts/Comment.tsx
@@ -1,17 +1,14 @@
 "use client";
 
-import Button from "@/components/common/ui/Button";
 import { useState } from "react";
-
-export interface CommentProps {
-  username: string;
-  content: string;
-  timestamp: string;
-  depth: number;
-  replies?: CommentProps[];
-}
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { commentApi } from "@/api/comments/comments";
+import Button from "@/components/common/ui/Button";
+import { CommentProps } from "@/lib/comments/types";
 
 export default function Comment({
+  id,
+  postId,
   username,
   content,
   timestamp,
@@ -19,14 +16,58 @@ export default function Comment({
   replies,
 }: CommentProps) {
   const [isReplying, setIsReplying] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
   const [replyContent, setReplyContent] = useState("");
+  const [editContent, setEditContent] = useState(content);
+  const queryClient = useQueryClient();
+
+  const addReplyMutation = useMutation({
+    mutationFn: (
+      newReply: Omit<CommentProps, "id" | "timestamp" | "replies">
+    ) => commentApi.addComment(newReply),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["comments", postId] });
+      setIsReplying(false);
+      setReplyContent("");
+    },
+  });
+
+  const updateCommentMutation = useMutation({
+    mutationFn: ({ id, content }: { id: string; content: string }) =>
+      commentApi.updateComment(id, content),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["comments", postId] });
+      setIsEditing(false);
+    },
+  });
+
+  const deleteCommentMutation = useMutation({
+    mutationFn: commentApi.deleteComment,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["comments", postId] });
+    },
+  });
 
   const handleReplySubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    // 댓글 작성 로직
-    console.log("Submitted reply:", replyContent);
-    setReplyContent("");
-    setIsReplying(false);
+    addReplyMutation.mutate({
+      postId,
+      username: "Current User", // 실제 사용자 정보로 대체해야 합니다
+      content: replyContent,
+      parentId: id,
+      depth: depth + 1,
+    });
+  };
+
+  const handleEditSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    updateCommentMutation.mutate({ id, content: editContent });
+  };
+
+  const handleDelete = () => {
+    if (window.confirm("정말로 이 댓글을 삭제하시겠습니까?")) {
+      deleteCommentMutation.mutate(id);
+    }
   };
 
   return (
@@ -35,14 +76,49 @@ export default function Comment({
         <span className="font-semibold">{username}</span>
         <span className="text-sm text-gray-500">{timestamp}</span>
       </div>
-      <p className="mt-1">{content}</p>
-      {depth === 0 && (
-        <button
-          className="mt-1 text-sm text-font_sub hover:text-main"
-          onClick={() => setIsReplying(!isReplying)}
-        >
-          답글 쓰기
-        </button>
+      {isEditing ? (
+        <form onSubmit={handleEditSubmit} className="mt-2">
+          <input
+            type="text"
+            value={editContent}
+            onChange={(e) => setEditContent(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-main"
+          />
+          <div className="mt-2 space-x-2">
+            <Button type="submit" label="수정하기" />
+            <Button
+              type="button"
+              label="취소"
+              onClick={() => setIsEditing(false)}
+            />
+          </div>
+        </form>
+      ) : (
+        <p className="mt-1">{content}</p>
+      )}
+      {!isEditing && (
+        <div className="mt-1 space-x-2">
+          {depth === 0 && (
+            <button
+              className="text-sm text-font_sub hover:text-main"
+              onClick={() => setIsReplying(!isReplying)}
+            >
+              답글 쓰기
+            </button>
+          )}
+          <button
+            className="text-sm text-font_sub hover:text-main"
+            onClick={() => setIsEditing(true)}
+          >
+            수정
+          </button>
+          <button
+            className="text-sm text-font_sub hover:text-main"
+            onClick={handleDelete}
+          >
+            삭제
+          </button>
+        </div>
       )}
       {isReplying && (
         <form onSubmit={handleReplySubmit} className="mt-2">
@@ -58,10 +134,7 @@ export default function Comment({
           </div>
         </form>
       )}
-      {replies &&
-        replies.map((reply, index) => (
-          <Comment key={index} {...reply} depth={depth + 1} />
-        ))}
+      {replies && replies.map((reply) => <Comment key={reply.id} {...reply} />)}
     </div>
   );
 }

--- a/src/components/posts/Comment.tsx
+++ b/src/components/posts/Comment.tsx
@@ -12,13 +12,14 @@ export default function Comment({
   username,
   content,
   timestamp,
-  depth,
+  depth = 0, // depth의 기본값을 0으로 설정
   replies,
 }: CommentProps) {
   const [isReplying, setIsReplying] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [replyContent, setReplyContent] = useState("");
   const [editContent, setEditContent] = useState(content);
+
   const queryClient = useQueryClient();
 
   const addReplyMutation = useMutation({
@@ -55,7 +56,7 @@ export default function Comment({
       username: "Current User", // 실제 사용자 정보로 대체해야 합니다
       content: replyContent,
       parentId: id,
-      depth: depth + 1,
+      depth: depth + 1, // 부모 댓글의 depth에 1을 더합니다
     });
   };
 
@@ -71,7 +72,9 @@ export default function Comment({
   };
 
   return (
-    <div className={`mt-4 ${depth > 0 ? "pl-5" : ""}`}>
+    <div
+      className={`mt-4 ${depth > 0 ? "pl-8 border-l-2 border-gray-200" : ""}`}
+    >
       <div className="flex justify-between items-center">
         <span className="font-semibold">{username}</span>
         <span className="text-sm text-gray-500">{timestamp}</span>
@@ -98,13 +101,15 @@ export default function Comment({
       )}
       {!isEditing && (
         <div className="mt-1 space-x-2">
-          {depth === 0 && (
-            <button
-              className="text-sm text-font_sub hover:text-main"
-              onClick={() => setIsReplying(!isReplying)}
-            >
-              답글 쓰기
-            </button>
+          {(depth === 0 || depth === undefined) && (
+            <>
+              <button
+                className="text-sm text-font_sub hover:text-main"
+                onClick={() => setIsReplying(!isReplying)}
+              >
+                답글 쓰기
+              </button>
+            </>
           )}
           <button
             className="text-sm text-font_sub hover:text-main"
@@ -120,7 +125,7 @@ export default function Comment({
           </button>
         </div>
       )}
-      {isReplying && (
+      {isReplying && depth === 0 && (
         <form onSubmit={handleReplySubmit} className="mt-2">
           <div className="flex items-center space-x-2">
             <input

--- a/src/components/posts/Comment.tsx
+++ b/src/components/posts/Comment.tsx
@@ -6,13 +6,23 @@ import { commentApi } from "@/api/comments/comments";
 import Button from "@/components/common/ui/Button";
 import { CommentProps } from "@/lib/comments/types";
 
+const formatTimestamp = (timestamp: string) => {
+  const date = new Date(timestamp);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day} ${hours}:${minutes}`;
+};
+
 export default function Comment({
   id,
   postId,
   username,
   content,
   timestamp,
-  depth = 0, // depth의 기본값을 0으로 설정
+  depth = 0,
   replies,
 }: CommentProps) {
   const [isReplying, setIsReplying] = useState(false);
@@ -53,10 +63,10 @@ export default function Comment({
     e.preventDefault();
     addReplyMutation.mutate({
       postId,
-      username: "Current User", // 실제 사용자 정보로 대체해야 합니다
+      username: "Current User", // 유저 정보로 대체해야 함
       content: replyContent,
       parentId: id,
-      depth: depth + 1, // 부모 댓글의 depth에 1을 더합니다
+      depth: depth + 1,
     });
   };
 
@@ -66,7 +76,7 @@ export default function Comment({
   };
 
   const handleDelete = () => {
-    if (window.confirm("정말로 이 댓글을 삭제하시겠습니까?")) {
+    if (window.confirm("댓글을 삭제하시겠습니까?")) {
       deleteCommentMutation.mutate(id);
     }
   };
@@ -77,7 +87,9 @@ export default function Comment({
     >
       <div className="flex justify-between items-center">
         <span className="font-semibold">{username}</span>
-        <span className="text-sm text-gray-500">{timestamp}</span>
+        <span className="text-sm text-gray-500">
+          {formatTimestamp(timestamp)}
+        </span>
       </div>
       {isEditing ? (
         <form onSubmit={handleEditSubmit} className="mt-2">

--- a/src/components/posts/CommentSection.tsx
+++ b/src/components/posts/CommentSection.tsx
@@ -28,7 +28,7 @@ export function CommentSection({ postId }: CommentSectionProps) {
     mutationFn: (
       newCommentData: Omit<CommentProps, "id" | "timestamp" | "replies">
     ) => commentApi.addComment(newCommentData),
-    onSuccess: (newComment) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["comments", postId] });
       setNewComment("");
     },

--- a/src/components/posts/CommentSection.tsx
+++ b/src/components/posts/CommentSection.tsx
@@ -1,45 +1,81 @@
-import { useState } from "react";
-import Button from "../common/ui/Button";
-import Comment from "@/components/posts/Comment";
-import { CommentProps } from "@/components/posts/Comment";
+"use client";
 
-export function CommentsSection() {
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { commentApi } from "@/api/comments/comments";
+import Button from "@/components/common/ui/Button";
+import Comment from "@/components/posts/Comment";
+import { CommentProps } from "@/lib/comments/types";
+
+interface CommentSectionProps {
+  postId: string;
+}
+
+export function CommentSection({ postId }: CommentSectionProps) {
   const [newComment, setNewComment] = useState("");
+  const queryClient = useQueryClient();
+
+  const {
+    data: comments,
+    isLoading,
+    error,
+  } = useQuery<CommentProps[]>({
+    queryKey: ["comments", postId],
+    queryFn: () => commentApi.getComments(postId),
+  });
+
+  const addCommentMutation = useMutation({
+    mutationFn: (
+      newCommentData: Omit<CommentProps, "id" | "timestamp" | "replies">
+    ) => commentApi.addComment(newCommentData),
+    onSuccess: (newComment) => {
+      queryClient.invalidateQueries({ queryKey: ["comments", postId] });
+      setNewComment("");
+    },
+  });
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    console.log("Submitted comment:", newComment);
-    setNewComment("");
+    addCommentMutation.mutate({
+      postId,
+      username: "Current User", // 실제 현재 사용자로 교체해야 합니다
+      content: newComment,
+      depth: 0, // 새 댓글은 항상 최상위 레벨이므로 depth를 0으로 설정
+    });
   };
 
-  const comments: CommentProps[] = [
-    {
-      username: "닉네임1",
-      content: "첫 번째 댓글 내용입니다.",
-      timestamp: "2024. 10. 18 20:30",
-      depth: 0,
-      replies: [
-        {
-          username: "닉네임2",
-          content: "첫 번째 댓글의 답글입니다.",
-          timestamp: "2024. 10. 18 20:35",
-          depth: 1,
-        },
-      ],
-    },
-    {
-      username: "닉네임4",
-      content: "두 번째 댓글 내용입니다.",
-      timestamp: "2024. 10. 18 21:00",
-      depth: 0,
-    },
-  ];
+  if (isLoading) return <div>댓글을 불러오는 중...</div>;
+  if (error) return <div>댓글을 불러오는데 실패했습니다.</div>;
+
+  const buildCommentTree = (comments: CommentProps[]): CommentProps[] => {
+    const commentMap = new Map<string, CommentProps>();
+    comments.forEach((comment) =>
+      commentMap.set(comment.id, { ...comment, replies: [] })
+    );
+
+    const rootComments: CommentProps[] = [];
+    commentMap.forEach((comment) => {
+      if (!comment.parentId) {
+        rootComments.push(comment);
+      } else {
+        const parentComment = commentMap.get(comment.parentId);
+        if (parentComment) {
+          parentComment.replies = parentComment.replies || [];
+          parentComment.replies.push(comment);
+        }
+      }
+    });
+
+    return rootComments;
+  };
+
+  const commentTree = buildCommentTree(comments || []);
 
   return (
     <div className="max-w-3xl mx-auto mt-8 px-4 sm:px-6 lg:px-8">
       <h2 className="text-xl font-semibold mb-4">댓글</h2>
-      {comments.map((comment, index) => (
-        <Comment key={index} {...comment} />
+      {commentTree.map((comment) => (
+        <Comment key={comment.id} {...comment} />
       ))}
       <form onSubmit={handleSubmit} className="mt-6">
         <div className="flex items-center space-x-2">

--- a/src/components/posts/CommentSection.tsx
+++ b/src/components/posts/CommentSection.tsx
@@ -38,9 +38,9 @@ export function CommentSection({ postId }: CommentSectionProps) {
     e.preventDefault();
     addCommentMutation.mutate({
       postId,
-      username: "Current User", // 실제 현재 사용자로 교체해야 합니다
+      username: "Current User", // 유저 정보로 대체해야 함
       content: newComment,
-      depth: 0, // 새 댓글은 항상 최상위 레벨이므로 depth를 0으로 설정
+      depth: 0,
     });
   };
 

--- a/src/lib/comments/types.ts
+++ b/src/lib/comments/types.ts
@@ -1,0 +1,10 @@
+export interface CommentProps {
+  id: string;
+  postId: string;
+  username: string;
+  content: string;
+  timestamp: string;
+  parentId?: string;
+  depth: number;
+  replies?: CommentProps[];
+}

--- a/src/store/comments/commentStore.tsx
+++ b/src/store/comments/commentStore.tsx
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+import { CommentProps } from "@/lib/comments/types";
+
+interface CommentStore {
+  comments: CommentProps[];
+  setComments: (comments: CommentProps[]) => void;
+  addComment: (comment: CommentProps) => void;
+  updateComment: (id: string, content: string) => void;
+  deleteComment: (id: string) => void;
+}
+
+export const useCommentStore = create<CommentStore>((set) => ({
+  comments: [],
+  setComments: (comments) => set({ comments }),
+  addComment: (comment) =>
+    set((state) => ({ comments: [comment, ...state.comments] })),
+  updateComment: (id, content) =>
+    set((state) => ({
+      comments: state.comments.map((c) =>
+        c.id === id ? { ...c, content } : c
+      ),
+    })),
+  deleteComment: (id) =>
+    set((state) => ({
+      comments: state.comments.filter((c) => c.id !== id),
+    })),
+}));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#5 

## 반영 브랜치

> feat/comment-fetch -> dev

## 📝 작업 내용

1. 댓글 기능 구현
- 댓글 작성
- 댓글 수정
- 댓글 삭제
- 게시글 상세페이지에서 전체 댓글 조회

2. 대댓글 기능 구현
-  최상위 댓글인 경우에만 대댓글 작성 가능하도록 구현
- 대댓글 수정
- 대댓글 삭제

3. 댓글 작성 시각 표기 형태 수정 
- 2024-11-04 21:05 형태로 표시

4. 댓글 정렬 구현
- 댓글 작성 시각 기준으로 오름차순 정렬

> 스크린샷 첨부 (선택)

![image](https://github.com/user-attachments/assets/30a67b76-8189-4b95-ac21-428fbc5902fe)
