### PR TITLE
Refactor: 메인페이지 초기데이터 프리패치, SSR 적용

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -27,7 +27,7 @@ export async function POST(request: Request) {
         nickname: user.displayName || userData.nickname || "",
         name: userData.name || "",
         birthdate: userData.birthdate || "",
-        profileImg: user.photoURL || userData.profileImg || "",
+        profileImg: userData.profileImg || "",
       },
       token,
     });

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -51,7 +51,7 @@ export default function LoginForm() {
         uid: data.user.uid,
         email: data.user.email ?? "",
         nickname: data.user.nickname ?? "",
-        profileImg: data.user.photoURL ?? "",
+        profileImg: data.user.profileImg ?? "",
         name: data.user.name ?? "",
         birthdate: data.user.birthdate ?? "",
       };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,32 @@
 import PostList from "@/components/posts/PostList";
+import { fetchPosts, POSTS_PER_PAGE } from "@/lib/api";
+import { Post } from "@/lib/posts/types";
+import {
+  HydrationBoundary,
+  QueryClient,
+  dehydrate,
+} from "@tanstack/react-query";
 
-export default function Home() {
+export default async function Home() {
+  const queryClient = new QueryClient();
+  const initialPosts = await fetchPosts(1);
+
+  await queryClient.prefetchInfiniteQuery({
+    queryKey: ["posts"],
+    queryFn: ({ pageParam = 1 }) => fetchPosts(pageParam),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage: Post[], allPages: Post[][]) => {
+      return lastPage.length === POSTS_PER_PAGE
+        ? allPages.length + 1
+        : undefined;
+    },
+  });
+
   return (
     <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <PostList />
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <PostList initialPosts={initialPosts} />
+      </HydrationBoundary>
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,7 +25,7 @@ export default async function Home() {
   return (
     <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <HydrationBoundary state={dehydrate(queryClient)}>
-        <PostList initialPosts={initialPosts} />
+        <PostList />
       </HydrationBoundary>
     </main>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,6 @@ import {
 
 export default async function Home() {
   const queryClient = new QueryClient();
-  const initialPosts = await fetchPosts(1);
 
   await queryClient.prefetchInfiniteQuery({
     queryKey: ["posts"],

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -10,7 +10,6 @@ export default function Profile() {
   const user = useStore(useAuthStore, (state) => {
     return state.user;
   });
-
   const ProfileData: ProfileData = {
     nickname: user?.nickname ?? "",
     email: user?.email ?? "",

--- a/src/components/posts/PostImageUploader.tsx
+++ b/src/components/posts/PostImageUploader.tsx
@@ -14,7 +14,7 @@ export function PostImageUploader({
   const [previewUrls, setPreviewUrls] = useState<string[]>([]);
 
   useEffect(() => {
-    // Create preview URLs for initial images
+    // 첫 이미지 미리보기
     setPreviewUrls(initialImages);
   }, [initialImages]);
 
@@ -23,7 +23,7 @@ export function PostImageUploader({
       const newFiles = Array.from(e.target.files);
       setImages((prevImages) => [...prevImages, ...newFiles]);
 
-      // Create preview URLs for new images
+      // 새로운 이미지 미리보기 url
       const newUrls = newFiles.map((file) => URL.createObjectURL(file));
       setPreviewUrls((prevUrls) => [...prevUrls, ...newUrls]);
     }

--- a/src/components/posts/PostList.tsx
+++ b/src/components/posts/PostList.tsx
@@ -6,10 +6,14 @@ import { useEffect } from "react";
 import ContentBox from "@/components/common/ui/ContentBox";
 import WriteButton from "@/components/common/ui/WriteButton";
 import { Footer } from "@/components/common/ui/footer/Footer";
-import { fetchPosts } from "@/lib/api";
+import { fetchPosts, POSTS_PER_PAGE } from "@/lib/api";
 import { Post } from "@/lib/posts/types";
 
-export default function PostList() {
+interface PostListProps {
+  initialPosts: Post[];
+}
+
+export default function PostList({ initialPosts }: PostListProps) {
   const { ref, inView } = useInView();
 
   const {
@@ -23,7 +27,7 @@ export default function PostList() {
     queryKey: ["posts"],
     queryFn: ({ pageParam = 1 }) => fetchPosts(pageParam),
     getNextPageParam: (lastPage, pages) => {
-      return lastPage.length === 10 ? pages.length + 1 : undefined;
+      return lastPage.length === POSTS_PER_PAGE ? pages.length + 1 : undefined;
     },
     initialPageParam: 1,
   });

--- a/src/components/posts/PostList.tsx
+++ b/src/components/posts/PostList.tsx
@@ -13,7 +13,7 @@ interface PostListProps {
   initialPosts: Post[];
 }
 
-export default function PostList({ initialPosts }: PostListProps) {
+export default function PostList() {
   const { ref, inView } = useInView();
 
   const {

--- a/src/components/posts/PostList.tsx
+++ b/src/components/posts/PostList.tsx
@@ -9,10 +9,6 @@ import { Footer } from "@/components/common/ui/footer/Footer";
 import { fetchPosts, POSTS_PER_PAGE } from "@/lib/api";
 import { Post } from "@/lib/posts/types";
 
-interface PostListProps {
-  initialPosts: Post[];
-}
-
 export default function PostList() {
   const { ref, inView } = useInView();
 

--- a/src/components/profile/ProfileImage.tsx
+++ b/src/components/profile/ProfileImage.tsx
@@ -1,12 +1,18 @@
 import Image from "next/image";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 interface ProfileImageProps {
   imageUrl?: string;
 }
 
 export function ProfileImage({ imageUrl }: ProfileImageProps) {
-  const [imgSrc, setImgSrc] = useState(imageUrl || "/images/user.png");
+  const [imgSrc, setImgSrc] = useState("/images/user.png");
+
+  useEffect(() => {
+    if (imageUrl) {
+      setImgSrc(imageUrl);
+    }
+  });
 
   return (
     <div className="flex justify-center w-28 h-28 rounded-full overflow-hidden mx-auto">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,11 @@
 import { Post } from "./posts/types";
 
-export async function fetchPosts(page = 1, limit = 10): Promise<Post[]> {
-  const response = await fetch(`/api/posts?page=${page}&limit=${limit}`);
+export const POSTS_PER_PAGE = 9;
+
+export async function fetchPosts(page: number): Promise<Post[]> {
+  const response = await fetch(
+    `http://localhost:3000/api/posts?page=${page}&limit=${POSTS_PER_PAGE}`
+  );
   if (!response.ok) {
     throw new Error("Failed to fetch posts");
   }

--- a/src/lib/auth/login/types.ts
+++ b/src/lib/auth/login/types.ts
@@ -6,7 +6,7 @@ export interface LoginCredentials {
 export interface LoginResponse {
   user: {
     birthdate: string;
-    photoURL: string;
+    profileImg: string;
     displayName: string;
     uid: string;
     email: string;

--- a/src/store/auth/authStore.ts
+++ b/src/store/auth/authStore.ts
@@ -29,7 +29,7 @@ export const useAuthStore = create(
                       name: userData.name || "",
                       nickname: userData.nickname || "",
                       birthdate: userData.birthdate || "",
-                      profileImg: userData.photoURL || "",
+                      profileImg: userData.profileImg || "",
                     },
                     isLogin: true,
                   });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#17 #22 

## 반영 브랜치

fix/main-fetch -> dev

## 📝 작업 내용

메인페이지 초기 데이터 리스트에 프리패치 적용
서버 사이드 렌더링으로 빠르게 메인페이지 게시글 정보에 진입 가능하도록 사용자 경험 개선


### 테스트 결과

![image](https://github.com/user-attachments/assets/3646ea58-9f01-442c-a818-f4833efae304)
![image](https://github.com/user-attachments/assets/9d63c33d-de5c-4627-b52d-42d03b5e3049)

