### PR TITLE
Refactor: 게시글 상세페이지 SSR 적용, 댓글 무한스크롤 구현

### DIFF
--- a/src/api/comments/comments.ts
+++ b/src/api/comments/comments.ts
@@ -2,13 +2,30 @@ import { CommentProps } from "@/lib/comments/types";
 
 const API_URL = "/api/comments";
 
+export interface CommentApiResponse {
+  comments: CommentProps[];
+  hasNextPage: boolean;
+  nextPage: number | null;
+}
+
 export const commentApi = {
-  getComments: async (postId: string): Promise<CommentProps[]> => {
-    const response = await fetch(`${API_URL}?postId=${postId}`);
+  getComments: async (
+    postId: string,
+    page: number = 0,
+    limit: number = 10
+  ): Promise<CommentApiResponse> => {
+    const response = await fetch(
+      `${API_URL}?postId=${postId}&page=${page}&limit=${limit}`
+    );
     if (!response.ok) {
       throw new Error("Failed to fetch comments");
     }
-    return response.json();
+    const data = await response.json();
+    return {
+      comments: data.comments,
+      hasNextPage: data.hasNextPage,
+      nextPage: data.nextPage,
+    };
   },
 
   addComment: async (

--- a/src/api/posts/posts.ts
+++ b/src/api/posts/posts.ts
@@ -2,7 +2,7 @@ import { Post } from "@/lib/posts/types";
 import { useAuthStore } from "@/store/auth/authStore";
 
 export async function fetchPost(id: string): Promise<Post> {
-  const response = await fetch(`/api/posts/${id}`);
+  const response = await fetch(`http://localhost:3000/api/posts/${id}`);
   if (!response.ok) {
     throw new Error("게시글을 불러오는데 실패했습니다.");
   }

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -12,10 +12,13 @@ import {
   orderBy,
   Timestamp,
   getDoc,
+  limit,
+  startAfter,
 } from "firebase/firestore";
 
 const COMMENTS_COLLECTION = "comments";
 const USERS_COLLECTION = "users";
+const COMMENTS_PER_PAGE = 10;
 
 const createErrorResponse = (message: string, status: number) => {
   return NextResponse.json({ error: message }, { status });
@@ -40,6 +43,11 @@ async function fetchUserProfile(uid: string) {
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const postId = searchParams.get("postId");
+  const page = parseInt(searchParams.get("page") || "0", 10);
+  const pageSize = parseInt(
+    searchParams.get("limit") || String(COMMENTS_PER_PAGE),
+    10
+  );
 
   if (!postId) {
     return createErrorResponse("Post ID is required", 400);
@@ -47,14 +55,28 @@ export async function GET(request: NextRequest) {
 
   try {
     const commentsRef = collection(db, COMMENTS_COLLECTION);
-    const q = query(
+    let q = query(
       commentsRef,
       where("postId", "==", postId),
-      orderBy("timestamp", "asc")
+      orderBy("timestamp", "desc"),
+      limit(pageSize + 1) // 다음 페이지 존재 여부를 확인하기 위해 1개 더 가져옵니다.
     );
+
+    // 첫 페이지가 아닌 경우, 시작점을 설정합니다.
+    if (page > 0) {
+      const lastVisibleSnapshot = await getLastVisibleSnapshot(
+        postId,
+        page,
+        pageSize
+      );
+      if (lastVisibleSnapshot) {
+        q = query(q, startAfter(lastVisibleSnapshot));
+      }
+    }
+
     const querySnapshot = await getDocs(q);
     const comments = await Promise.all(
-      querySnapshot.docs.map(async (doc) => {
+      querySnapshot.docs.slice(0, pageSize).map(async (doc) => {
         const commentData = doc.data();
         const userProfile = await fetchUserProfile(commentData.uid);
         return {
@@ -67,11 +89,33 @@ export async function GET(request: NextRequest) {
       })
     );
 
-    return NextResponse.json(comments);
+    const hasNextPage = querySnapshot.docs.length > pageSize;
+
+    return NextResponse.json({
+      comments,
+      hasNextPage,
+      nextPage: hasNextPage ? page + 1 : null,
+    });
   } catch (error) {
     console.error("Error fetching comments:", error);
     return createErrorResponse("Failed to fetch comments", 500);
   }
+}
+
+async function getLastVisibleSnapshot(
+  postId: string,
+  page: number,
+  pageSize: number
+) {
+  const commentsRef = collection(db, COMMENTS_COLLECTION);
+  const q = query(
+    commentsRef,
+    where("postId", "==", postId),
+    orderBy("timestamp", "desc"),
+    limit(page * pageSize)
+  );
+  const querySnapshot = await getDocs(q);
+  return querySnapshot.docs[querySnapshot.docs.length - 1];
 }
 
 // 댓글 작성 로직

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -1,63 +1,21 @@
-"use client";
-
-import { useRouter, useParams } from "next/navigation";
+import { Suspense } from "react";
+import { notFound } from "next/navigation";
 import { PostContent } from "@/components/posts/PostContent";
 import { CommentSection } from "@/components/comments/CommentSection";
 import { AuthorInfo } from "@/components/posts/AuthorInfo";
-import { usePostStore } from "@/store/posts/postStore";
-import { usePostQuery } from "@/lib/posts/hooks/usePostQuery";
-import { usePostMutations } from "@/lib/posts/hooks/usePostMutations";
-import { useEffect } from "react";
+import { fetchPost } from "@/api/posts/posts";
 
-export default function PostDetailPage() {
-  const router = useRouter();
-  const params = useParams();
-  const postId = params.id as string;
+export default async function PostDetailPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const postId = params.id;
+  const post = await fetchPost(postId);
 
-  const { setCurrentPost, setError, setLoading } = usePostStore();
-  const { deletePostMutation } = usePostMutations();
-
-  const { data: post, isLoading, error } = usePostQuery(postId);
-
-  useEffect(() => {
-    if (post) {
-      setCurrentPost(post);
-      setLoading(false);
-      setError(null);
-    }
-  }, [post, setCurrentPost, setLoading, setError]);
-
-  useEffect(() => {
-    if (error) {
-      setError(error.message);
-      setLoading(false);
-    }
-  }, [error, setError, setLoading]);
-
-  const handleDelete = async () => {
-    if (window.confirm("게시글을 삭제하시겠습니까?")) {
-      try {
-        await deletePostMutation.mutateAsync(postId);
-        router.push("/");
-      } catch (error) {
-        console.error("게시물 삭제 실패:", error);
-      }
-    }
-  };
-
-  if (isLoading) return <div className="text-center mt-8">로딩 중...</div>;
-  if (error)
-    return (
-      <div className="text-center mt-8 text-red-500">
-        게시글을 불러오는데 실패했습니다: {error.message}
-      </div>
-    );
-  if (!post)
-    return (
-      <div className="text-center mt-8 text-red-500">
-        게시글을 찾을 수 없습니다.
-      </div>
-    );
+  if (!post) {
+    notFound();
+  }
 
   return (
     <div className="min-h-screen bg-gray-100">
@@ -65,10 +23,12 @@ export default function PostDetailPage() {
         <div className="max-w-4xl mx-auto bg-bg rounded-lg overflow-hidden">
           <div className="p-6">
             <AuthorInfo author={post.author} />
-            <PostContent post={post} onDelete={handleDelete} />
+            <PostContent post={post} />
           </div>
         </div>
-        <CommentSection postId={postId} />
+        <Suspense fallback={<div>Loading comments...</div>}>
+          <CommentSection postId={postId} />
+        </Suspense>
       </main>
     </div>
   );

--- a/src/components/comments/CommentSection.tsx
+++ b/src/components/comments/CommentSection.tsx
@@ -1,30 +1,51 @@
 "use client";
 
 import { useState } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { commentApi } from "@/api/comments/comments";
 import Button from "@/components/common/ui/Button";
 import Comment from "@/components/comments/Comment";
 import { CommentProps, UserProfile } from "@/lib/comments/types";
 import { useAuthStore } from "@/store/auth/authStore";
+import { useInView } from "react-intersection-observer";
+import { useEffect } from "react";
+
+interface CommentApiResponse {
+  comments: CommentProps[];
+  hasNextPage: boolean;
+  nextPage: number | null;
+}
 
 interface CommentSectionProps {
   postId: string;
 }
 
+const COMMENTS_PER_PAGE = 10;
+
 export function CommentSection({ postId }: CommentSectionProps) {
   const [newComment, setNewComment] = useState("");
   const queryClient = useQueryClient();
   const { user } = useAuthStore();
+  const { ref, inView } = useInView();
 
-  const {
-    data: comments,
-    isLoading,
-    error,
-  } = useQuery<CommentProps[]>({
-    queryKey: ["comments", postId],
-    queryFn: () => commentApi.getComments(postId),
-  });
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } =
+    useInfiniteQuery<CommentApiResponse, Error>({
+      queryKey: ["comments", postId],
+      queryFn: ({ pageParam = 0 }) =>
+        commentApi.getComments(postId, pageParam as number, COMMENTS_PER_PAGE),
+      getNextPageParam: (lastPage) => lastPage.nextPage,
+      initialPageParam: 0,
+    });
+
+  useEffect(() => {
+    if (inView && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, fetchNextPage, hasNextPage]);
 
   const addCommentMutation = useMutation({
     mutationFn: (
@@ -54,39 +75,26 @@ export function CommentSection({ postId }: CommentSectionProps) {
     }
   };
 
-  if (isLoading) return <div>댓글을 불러오는 중...</div>;
-  if (error) return <div>댓글을 불러오는데 실패했습니다.</div>;
+  if (status === "pending") return <div>댓글을 불러오는 중...</div>;
+  if (status === "error") return <div>댓글을 불러오는데 실패했습니다.</div>;
 
-  const buildCommentTree = (comments: CommentProps[]): CommentProps[] => {
-    const commentMap = new Map<string, CommentProps>();
-    comments.forEach((comment) =>
-      commentMap.set(comment.id, { ...comment, replies: [] })
-    );
-
-    const rootComments: CommentProps[] = [];
-    commentMap.forEach((comment) => {
-      if (comment.depth === 0) {
-        rootComments.push(comment);
-      } else {
-        const parentComment = comments.find((c) => c.id === comment.parentId);
-        if (parentComment) {
-          parentComment.replies = parentComment.replies || [];
-          parentComment.replies.push(comment);
-        }
-      }
-    });
-
-    return rootComments;
-  };
-
-  const commentTree = buildCommentTree(comments || []);
+  const comments = data?.pages.flatMap((page) => page.comments) || [];
 
   return (
     <div className="max-w-3xl mx-auto mt-8 px-4 sm:px-6 lg:px-8">
       <h2 className="text-xl font-semibold mb-4">댓글</h2>
-      {commentTree.map((comment) => (
+      {comments.map((comment) => (
         <Comment key={comment.id} {...comment} />
       ))}
+      <div className="mt-8 text-xs font-semibold text-font_sub">
+        {isFetchingNextPage ? (
+          <p>더 많은 댓글을 불러오는 중...</p>
+        ) : hasNextPage ? (
+          <div ref={ref} className="h-10" /> // Intersection observer를 위한 보이지 않는 요소
+        ) : (
+          <p>모든 댓글을 불러왔습니다.</p>
+        )}
+      </div>
       {user ? (
         <form onSubmit={handleSubmit} className="mt-6">
           <div className="flex items-center space-x-2">

--- a/src/components/posts/PostContent.tsx
+++ b/src/components/posts/PostContent.tsx
@@ -1,22 +1,35 @@
+"use client";
+
 import { useState } from "react";
 import { Bookmark, Trash2, Edit } from "lucide-react";
 import { Post } from "@/lib/posts/types";
 import { ImageSlider } from "./ImageSlider";
 import { useRouter } from "next/navigation";
 import { useAuthStore } from "@/store/auth/authStore";
+import { usePostMutations } from "@/lib/posts/hooks/usePostMutations";
 
 interface PostContentProps {
   post: Post;
-  onDelete: () => void;
 }
 
-export function PostContent({ post, onDelete }: PostContentProps) {
+export function PostContent({ post }: PostContentProps) {
   const [isScrap, setIsScrap] = useState(false);
   const router = useRouter();
+  const user = useAuthStore((state) => state.user);
+  const { deletePostMutation } = usePostMutations();
 
-  const user = useAuthStore();
-  const isAuthor = user.user?.uid === post.author?.id;
-  console.log(post.author);
+  const isAuthor = user?.uid === post.author?.id;
+
+  const handleDelete = async () => {
+    if (window.confirm("게시글을 삭제하시겠습니까?")) {
+      try {
+        await deletePostMutation.mutateAsync(post.id);
+        router.push("/");
+      } catch (error) {
+        console.error("게시물 삭제 실패:", error);
+      }
+    }
+  };
 
   return (
     <div className="max-w-3xl mx-auto mt-8 px-4 sm:px-6 lg:px-8 pb-8 border-b">
@@ -29,7 +42,7 @@ export function PostContent({ post, onDelete }: PostContentProps) {
               <button onClick={() => router.push(`/posts/${post.id}/edit`)}>
                 <Edit className="h-6 w-6 text-gray-500" />
               </button>
-              <button onClick={onDelete} className="text-red-500">
+              <button onClick={handleDelete} className="text-red-500">
                 <Trash2 className="h-6 w-6" />
               </button>
             </>

--- a/src/lib/firebase/firebaseConfig.ts
+++ b/src/lib/firebase/firebaseConfig.ts
@@ -34,18 +34,4 @@ setPersistence(auth, browserLocalPersistence)
     console.error("인증 상태 지속성 설정 중 오류 발생:", error);
   });
 
-// 디버깅을 위한 auth 상태 변경 리스너
-auth.onAuthStateChanged((user) => {
-  console.log("Auth state changed:", user ? user.uid : "No user");
-  console.log(user);
-  if (user) {
-    console.log("User is logged in:", user.uid);
-    user.getIdToken().then((token) => {
-      console.log("Token on sign-in:", token);
-    });
-  } else {
-    console.log("User is logged out.");
-  }
-});
-
 export { auth, db, storage };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#22 

## 반영 브랜치

refactor/post-fetch -> dev

## 📝 작업 내용

1. 게시글 상세페이지 서버 사이드 렌더링(SSR) 적용
- 게시글 상세페이지 진입 시, 사용자가 바로 접근 가능한 정보와 아닌 정보로 구분
- 게시글 사진과 상세내용은 바로 접근 가능해야 하는 정보이므로 SSR 적용

2. 댓글 무한스크롤 적용
- 댓글 영역에 무한스크롤을 적용해서 사용자가 스크롤함에 따라 댓글 데이터를 패칭

### 테스트 결과

![image](https://github.com/user-attachments/assets/41cb1e6f-6e35-434d-8d3f-683eed11202f)
![image](https://github.com/user-attachments/assets/2ed1a04d-1308-4911-aa8c-6fe7e0f18096)

