### PR TITLE
Feat: 회원가입 유효성 로직 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "^18",
         "react-intersection-observer": "^9.13.1",
         "stream-browserify": "^3.0.0",
+        "zod": "^3.23.8",
         "zustand": "^5.0.0"
       },
       "devDependencies": {
@@ -995,6 +996,126 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.15.tgz",
+      "integrity": "sha512-5TGyjFcf8ampZP3e+FyCax5zFVHi+Oe7sZyaKOngsqyaNEpOgkKB3sqmymkZfowy3ufGA/tUgDPPxpQx931lHg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.15.tgz",
+      "integrity": "sha512-3Bwv4oc08ONiQ3FiOLKT72Q+ndEMyLNsc/D3qnLMbtUYTQAmkx9E/JRu0DBpHxNddBmNT5hxz1mYBphJ3mfrrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.15.tgz",
+      "integrity": "sha512-k5xf/tg1FBv/M4CMd8S+JL3uV9BnnRmoe7F+GWC3DxkTCD9aewFRH1s5rJ1zkzDa+Do4zyN8qD0N8c84Hu96FQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.15.tgz",
+      "integrity": "sha512-kE6q38hbrRbKEkkVn62reLXhThLRh6/TvgSP56GkFNhU22TbIrQDEMrO7j0IcQHcew2wfykq8lZyHFabz0oBrA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.15.tgz",
+      "integrity": "sha512-PZ5YE9ouy/IdO7QVJeIcyLn/Rc4ml9M2G4y3kCM9MNf1YKvFY4heg3pVa/jQbMro+tP6yc4G2o9LjAz1zxD7tQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.15.tgz",
+      "integrity": "sha512-2raR16703kBvYEQD9HNLyb0/394yfqzmIeyp2nDzcPV4yPjqNUG3ohX6jX00WryXz6s1FXpVhsCo3i+g4RUX+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.15.tgz",
+      "integrity": "sha512-fyTE8cklgkyR1p03kJa5zXEaZ9El+kDNM5A+66+8evQS5e/6v0Gk28LqA0Jet8gKSOyP+OTm/tJHzMlGdQerdQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.15.tgz",
+      "integrity": "sha512-SzqGbsLsP9OwKNUG9nekShTwhj6JSB9ZLMWQ8g1gG6hdE5gQLncbnbymrwy2yVmH9nikSLYRYxYMFu78Ggp7/g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -7695,6 +7816,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/zustand": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.0.tgz",
@@ -7722,126 +7852,6 @@
         "use-sync-external-store": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.15.tgz",
-      "integrity": "sha512-5TGyjFcf8ampZP3e+FyCax5zFVHi+Oe7sZyaKOngsqyaNEpOgkKB3sqmymkZfowy3ufGA/tUgDPPxpQx931lHg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.15.tgz",
-      "integrity": "sha512-3Bwv4oc08ONiQ3FiOLKT72Q+ndEMyLNsc/D3qnLMbtUYTQAmkx9E/JRu0DBpHxNddBmNT5hxz1mYBphJ3mfrrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.15.tgz",
-      "integrity": "sha512-k5xf/tg1FBv/M4CMd8S+JL3uV9BnnRmoe7F+GWC3DxkTCD9aewFRH1s5rJ1zkzDa+Do4zyN8qD0N8c84Hu96FQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.15.tgz",
-      "integrity": "sha512-kE6q38hbrRbKEkkVn62reLXhThLRh6/TvgSP56GkFNhU22TbIrQDEMrO7j0IcQHcew2wfykq8lZyHFabz0oBrA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.15.tgz",
-      "integrity": "sha512-PZ5YE9ouy/IdO7QVJeIcyLn/Rc4ml9M2G4y3kCM9MNf1YKvFY4heg3pVa/jQbMro+tP6yc4G2o9LjAz1zxD7tQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.15.tgz",
-      "integrity": "sha512-2raR16703kBvYEQD9HNLyb0/394yfqzmIeyp2nDzcPV4yPjqNUG3ohX6jX00WryXz6s1FXpVhsCo3i+g4RUX+g==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.15.tgz",
-      "integrity": "sha512-fyTE8cklgkyR1p03kJa5zXEaZ9El+kDNM5A+66+8evQS5e/6v0Gk28LqA0Jet8gKSOyP+OTm/tJHzMlGdQerdQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.15.tgz",
-      "integrity": "sha512-SzqGbsLsP9OwKNUG9nekShTwhj6JSB9ZLMWQ8g1gG6hdE5gQLncbnbymrwy2yVmH9nikSLYRYxYMFu78Ggp7/g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^18",
     "react-intersection-observer": "^9.13.1",
     "stream-browserify": "^3.0.0",
+    "zod": "^3.23.8",
     "zustand": "^5.0.0"
   },
   "devDependencies": {

--- a/src/api/auth/signup.ts
+++ b/src/api/auth/signup.ts
@@ -14,9 +14,21 @@ export async function registerUser(
     body: JSON.stringify(userData),
   });
 
+  const data = await response.json();
+
   if (!response.ok) {
-    throw new Error("Registration failed");
+    throw new Error(data.error || "회원가입에 실패했습니다.");
   }
 
-  return response.json();
+  return data;
+}
+
+export async function checkNicknameAvailability(
+  nickname: string
+): Promise<boolean> {
+  const response = await fetch(
+    `/api/auth/signup/nicknameCheck?nickname=${encodeURIComponent(nickname)}`
+  );
+  const data = await response.json();
+  return data.available;
 }

--- a/src/app/api/auth/signup/nicknameCheck/route.ts
+++ b/src/app/api/auth/signup/nicknameCheck/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/firebase/firebaseConfig";
+import { collection, query, where, getDocs } from "firebase/firestore";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const nickname = searchParams.get("nickname");
+
+  if (!nickname) {
+    return NextResponse.json(
+      { error: "닉네임이 제공되지 않았습니다." },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const usersRef = collection(db, "users");
+    const q = query(usersRef, where("nickname", "==", nickname));
+    const querySnapshot = await getDocs(q);
+
+    const isAvailable = querySnapshot.empty;
+
+    return NextResponse.json({ available: isAvailable });
+  } catch (error) {
+    console.error("닉네임 확인 중 오류 발생:", error);
+    return NextResponse.json(
+      { error: "서버 오류가 발생했습니다." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,24 +1,56 @@
 import { auth, db, storage } from "@/lib/firebase/firebaseConfig";
 import { IUser } from "@/store/auth/types";
 import { createUserWithEmailAndPassword, updateProfile } from "firebase/auth";
-import { doc, setDoc } from "firebase/firestore";
+import {
+  doc,
+  setDoc,
+  getDoc,
+  collection,
+  query,
+  where,
+  getDocs,
+} from "firebase/firestore";
 import { getDownloadURL, ref, uploadString } from "firebase/storage";
 import { NextResponse } from "next/server";
-
-// const MAX_PROFILE_URL_LENGTH = 1024; // Firebase의 최대 URL 길이
+import { signupSchema } from "@/lib/auth/signup/validationSchemas";
 
 export async function POST(request: Request) {
   console.log("회원가입 요청 시작");
   try {
+    const body = await request.json();
+    const validationResult = signupSchema.safeParse(body);
+
+    if (!validationResult.success) {
+      return NextResponse.json(
+        { error: validationResult.error.errors },
+        { status: 400 }
+      );
+    }
+
     const { name, email, password, nickname, birthdate, profileImg } =
-      await request.json();
-    console.log("요청 데이터:", {
-      name,
-      email,
-      nickname,
-      birthdate,
-      profileImg: profileImg ? "있음" : "없음",
-    });
+      validationResult.data;
+
+    // 이메일 중복 확인
+    const emailDoc = await getDoc(doc(db, "users", email));
+    if (emailDoc.exists()) {
+      return NextResponse.json(
+        { error: "이미 사용 중인 이메일입니다." },
+        { status: 400 }
+      );
+    }
+
+    // 닉네임 중복 확인
+    const nicknameQuery = query(
+      collection(db, "users"),
+      where("nickname", "==", nickname)
+    );
+    const nicknameQuerySnapshot = await getDocs(nicknameQuery);
+    if (!nicknameQuerySnapshot.empty) {
+      return NextResponse.json(
+        { error: "이미 사용 중인 닉네임입니다." },
+        { status: 400 }
+      );
+    }
 
     console.log("Firebase Authentication으로 사용자 생성 시도");
     const userCredential = await createUserWithEmailAndPassword(
@@ -32,27 +64,24 @@ export async function POST(request: Request) {
     let profileImgUrl = null;
 
     if (profileImg) {
-      // Firebase Storage에 이미지 업로드
       const imageRef = ref(storage, `profile-images/${user.uid}`);
       await uploadString(imageRef, profileImg, "data_url");
       profileImgUrl = await getDownloadURL(imageRef);
     }
 
-    // 프로필 업데이트
     await updateProfile(user, {
       displayName: nickname,
       photoURL: profileImgUrl,
     });
     console.log("사용자 프로필 업데이트 성공");
 
-    // Firestore에 사용자 데이터 저장
     const userData: IUser = {
       uid: user.uid,
       email: user.email!,
       name: name,
       nickname: nickname,
       birthdate: birthdate,
-      profileImg: profileImgUrl, // 프로필 이미지는 url만 저장
+      profileImg: profileImgUrl,
     };
     console.log("Firestore에 사용자 데이터 저장 시도:", userData);
     await setDoc(doc(db, "users", user.uid), userData);

--- a/src/app/api/posts/[id]/route.ts
+++ b/src/app/api/posts/[id]/route.ts
@@ -6,7 +6,7 @@ import {
   getDownloadURL,
   deleteObject,
 } from "firebase/storage";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 // 이미지 업로드
 const uploadImageAndGetURL = async (
@@ -22,7 +22,10 @@ const uploadImageAndGetURL = async (
 };
 
 // GET: 단일 게시글 조회 로직
-export async function GET({ params }: { params: { id: string } }) {
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) {
   try {
     const docRef = doc(db, "posts", params.id);
     const docSnap = await getDoc(docRef);
@@ -65,7 +68,7 @@ export async function GET({ params }: { params: { id: string } }) {
 
 // PUT: 게시글 수정 로직
 export async function PUT(
-  request: Request,
+  request: NextRequest,
   { params }: { params: { id: string } }
 ) {
   try {

--- a/src/app/api/posts/[id]/route.ts
+++ b/src/app/api/posts/[id]/route.ts
@@ -143,7 +143,10 @@ export async function PUT(
 }
 
 // DELETE: 게시글 삭제 로직
-export async function DELETE({ params }: { params: { id: string } }) {
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) {
   try {
     const docRef = doc(db, "posts", params.id);
     const docSnap = await getDoc(docRef);

--- a/src/app/api/posts/[id]/route.ts
+++ b/src/app/api/posts/[id]/route.ts
@@ -22,10 +22,7 @@ const uploadImageAndGetURL = async (
 };
 
 // GET: 단일 게시글 조회 로직
-export async function GET(
-  request: Request,
-  { params }: { params: { id: string } }
-) {
+export async function GET({ params }: { params: { id: string } }) {
   try {
     const docRef = doc(db, "posts", params.id);
     const docSnap = await getDoc(docRef);
@@ -143,10 +140,7 @@ export async function PUT(
 }
 
 // DELETE: 게시글 삭제 로직
-export async function DELETE(
-  request: Request,
-  { params }: { params: { id: string } }
-) {
+export async function DELETE({ params }: { params: { id: string } }) {
   try {
     const docRef = doc(db, "posts", params.id);
     const docSnap = await getDoc(docRef);

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -16,6 +16,7 @@ import {
   passwordSchema,
   signupSchema,
 } from "../../lib/auth/signup/validationSchemas";
+import { RegisterResponse } from "@/lib/auth/signup/types";
 
 export default function SignupForm() {
   const [formData, setFormData] = useState<SignupFormData>({
@@ -40,7 +41,7 @@ export default function SignupForm() {
   const router = useRouter();
   const { setUser } = useAuthStore();
 
-  const mutation = useMutation<any, Error, SignupFormData>({
+  const mutation = useMutation<RegisterResponse, Error, SignupFormData>({
     mutationFn: registerUser,
     onSuccess: (data) => {
       setUser(data.user);
@@ -93,7 +94,7 @@ export default function SignupForm() {
           await passwordSchema.parseAsync(formData[field]);
         }
         setErrors((prev) => ({ ...prev, [field]: undefined }));
-      } catch (error) {
+      } catch (error: any) {
         if (error instanceof z.ZodError) {
           // ZodError 처리
           setErrors((prev) => ({ ...prev, [field]: error.errors[0].message }));

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -87,32 +87,19 @@ export default function SignupForm() {
   useEffect(() => {
     const validateField = async (field: "email" | "password") => {
       if (!touchedFields[field]) return;
+
       try {
-        if (field === "email") {
-          await emailSchema.parseAsync(formData[field]);
-        } else if (field === "password") {
-          await passwordSchema.parseAsync(formData[field]);
-        }
+        const schema = field === "email" ? emailSchema : passwordSchema;
+        await schema.parseAsync(formData[field]);
         setErrors((prev) => ({ ...prev, [field]: undefined }));
-      } catch (error: any) {
-        if (error instanceof z.ZodError) {
-          // ZodError 처리
-          setErrors((prev) => ({ ...prev, [field]: error.errors[0].message }));
-        } else if (error instanceof Error) {
-          // 일반적인 Error 처리
-          console.error("Unexpected error during validation:", error.message);
-          setErrors((prev) => ({
-            ...prev,
-            [field]: "알 수 없는 오류가 발생했습니다.",
-          }));
-        } else {
-          // 예상치 못한 오류 처리
-          console.error("Unknown error type:", error);
-          setErrors((prev) => ({
-            ...prev,
-            [field]: "알 수 없는 오류가 발생했습니다.",
-          }));
-        }
+      } catch (error: unknown) {
+        const errorMessage =
+          error instanceof z.ZodError
+            ? error.errors[0].message
+            : "알 수 없는 오류가 발생했습니다.";
+
+        console.error(`Error validating ${field}:`, error);
+        setErrors((prev) => ({ ...prev, [field]: errorMessage }));
       }
     };
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,82 +1,144 @@
 "use client";
 
-import { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMutation } from "@tanstack/react-query";
+import { z } from "zod";
 import Button from "@/components/common/ui/Button";
 import { useAuthStore } from "@/store/auth/authStore";
 import { ProfileImageUploader } from "@/components/auth/signup/ProfileImageUploader";
 import { FormInput } from "@/components/common/ui/FormInput";
-import { registerUser } from "../../api/auth/signup";
-import type {
-  RegisterUserData,
-  RegisterResponse,
-} from "../../lib/auth/signup/types";
-
-// FormData 타입 정의
-type FormData = {
-  name: string;
-  email: string;
-  password: string;
-  confirmPassword: string;
-  nickname: string;
-  birthdate: string;
-  profileImg: string | null;
-};
+import { registerUser, checkNicknameAvailability } from "../../api/auth/signup";
+import {
+  SignupFormData,
+  emailSchema,
+  passwordSchema,
+  signupSchema,
+} from "../../lib/auth/signup/validationSchemas";
 
 export default function SignupForm() {
-  const [formData, setFormData] = useState<FormData>({
+  const [formData, setFormData] = useState<SignupFormData>({
     name: "",
     email: "",
     password: "",
-    confirmPassword: "",
     nickname: "",
     birthdate: "",
     profileImg: null,
   });
 
+  const [errors, setErrors] = useState<
+    Partial<Record<keyof SignupFormData, string>>
+  >({});
+  const [touchedFields, setTouchedFields] = useState<
+    Partial<Record<keyof SignupFormData, boolean>>
+  >({});
+  const [isNicknameAvailable, setIsNicknameAvailable] = useState<
+    boolean | null
+  >(null);
+
   const router = useRouter();
   const { setUser } = useAuthStore();
 
-  const mutation = useMutation<RegisterResponse, Error, RegisterUserData>({
+  const mutation = useMutation<any, Error, SignupFormData>({
     mutationFn: registerUser,
     onSuccess: (data) => {
       setUser(data.user);
       alert(
-        `${formData.name}님, 회원가입이 완료되었습니다. 홈 페이지로 이동합니다.`
+        `${formData.name}님, 회원가입이 완료되었습니다. 로그인 페이지로 이동합니다.`
       );
-      router.push("/");
+      router.push("/login");
     },
-    onError: (error) => {
-      console.error("Registration error", error);
+    onError: (error: Error) => {
+      console.error("회원가입 에러", error);
       alert("회원가입에 실패했습니다.");
     },
   });
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (formData.password !== formData.confirmPassword) {
-      alert("비밀번호가 일치하지 않습니다.");
+    console.log("폼 제출됨"); // 디버깅
+    const validationResult = signupSchema.safeParse(formData);
+    if (!validationResult.success) {
+      const newErrors: Partial<Record<keyof SignupFormData, string>> = {};
+      validationResult.error.issues.forEach((issue) => {
+        if (issue.path[0]) {
+          newErrors[issue.path[0] as keyof SignupFormData] = issue.message;
+        }
+      });
+      setErrors(newErrors);
+      console.log("유효성 검사 실패"); // 디버깅
       return;
     }
-    // Omit을 사용하여 confirmPassword를 제외한 새로운 객체 생성
-    const userData: RegisterUserData = {
-      name: formData.name,
-      email: formData.email,
-      password: formData.password,
-      nickname: formData.nickname,
-      birthdate: formData.birthdate,
-      profileImg: formData.profileImg,
-    };
-    mutation.mutate(userData);
+    if (!isNicknameAvailable) {
+      alert("닉네임 중복 확인을 해주세요.");
+      return;
+    }
+    mutation.mutate(formData);
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormData((prev) => ({
-      ...prev,
-      [e.target.id]: e.target.value,
-    }));
+    const { id, value } = e.target;
+    setFormData((prev) => ({ ...prev, [id]: value }));
+    setTouchedFields((prev) => ({ ...prev, [id]: true }));
+  };
+
+  useEffect(() => {
+    const validateField = async (field: "email" | "password") => {
+      if (!touchedFields[field]) return;
+      try {
+        if (field === "email") {
+          await emailSchema.parseAsync(formData[field]);
+        } else if (field === "password") {
+          await passwordSchema.parseAsync(formData[field]);
+        }
+        setErrors((prev) => ({ ...prev, [field]: undefined }));
+      } catch (error: any) {
+        if (error instanceof z.ZodError) {
+          setErrors((prev) => ({ ...prev, [field]: error.errors[0].message }));
+        } else {
+          console.error("Unexpected error during validation:", error);
+          setErrors((prev) => ({
+            ...prev,
+            [field]: "알 수 없는 오류가 발생했습니다.",
+          }));
+        }
+      }
+    };
+
+    validateField("email");
+    validateField("password");
+  }, [formData.email, formData.password, touchedFields]);
+
+  const handleCheckNickname = async () => {
+    if (!formData.nickname) {
+      alert("닉네임을 입력해주세요.");
+      return;
+    }
+    try {
+      const isAvailable = await checkNicknameAvailability(formData.nickname);
+      setIsNicknameAvailable(isAvailable);
+      alert(
+        isAvailable
+          ? "사용 가능한 닉네임입니다."
+          : "이미 사용 중인 닉네임입니다."
+      );
+    } catch (error) {
+      console.error("닉네임 확인 에러", error);
+      alert("닉네임 확인에 실패했습니다.");
+    }
+  };
+
+  const isFormValid = () => {
+    return (
+      formData.name &&
+      formData.email &&
+      formData.password &&
+      formData.nickname &&
+      formData.birthdate &&
+      isNicknameAvailable
+      // Object.keys(errors).length === 0
+    );
   };
 
   return (
@@ -99,6 +161,7 @@ export default function SignupForm() {
                 value={formData.name}
                 onChange={handleChange}
                 placeholder="이름을 입력해주세요."
+                error={touchedFields.name ? errors.name : undefined}
               />
             </div>
           </div>
@@ -109,6 +172,7 @@ export default function SignupForm() {
             value={formData.email}
             onChange={handleChange}
             placeholder="이메일을 입력해주세요."
+            error={touchedFields.email ? errors.email : undefined}
           />
           <FormInput
             id="password"
@@ -117,23 +181,43 @@ export default function SignupForm() {
             value={formData.password}
             onChange={handleChange}
             placeholder="비밀번호를 입력해주세요."
+            error={touchedFields.password ? errors.password : undefined}
           />
-          <FormInput
-            id="confirmPassword"
-            label="비밀번호 확인"
-            type="password"
-            value={formData.confirmPassword}
-            onChange={handleChange}
-            placeholder="비밀번호를 한 번 더 입력해주세요."
-          />
-          <FormInput
-            id="nickname"
-            label="닉네임"
-            type="text"
-            value={formData.nickname}
-            onChange={handleChange}
-            placeholder="사용하실 닉네임을 입력해주세요."
-          />
+          <div className="space-y-2">
+            <label
+              htmlFor="nickname"
+              className="block text-sm font-medium text-gray-700"
+            >
+              닉네임
+            </label>
+            <div className="flex items-center gap-2">
+              <input
+                id="nickname"
+                type="text"
+                value={formData.nickname}
+                onChange={handleChange}
+                placeholder="사용하실 닉네임을 입력해주세요."
+                className={`flex-1 rounded-md border ${
+                  touchedFields.nickname && errors.nickname
+                    ? "border-red-500"
+                    : "border-gray-300"
+                } px-3 py-2 focus:outline-none focus:ring-border focus:border-border`}
+              />
+              <Button
+                label="중복확인"
+                onClick={handleCheckNickname}
+                type="button"
+              />
+            </div>
+            {touchedFields.nickname && errors.nickname && (
+              <p className="text-sm text-red-500">{errors.nickname}</p>
+            )}
+            {isNicknameAvailable === false && (
+              <p className="text-red-500 text-sm">
+                이미 사용 중인 닉네임입니다.
+              </p>
+            )}
+          </div>
           <FormInput
             id="birthdate"
             label="생년월일"
@@ -141,11 +225,12 @@ export default function SignupForm() {
             value={formData.birthdate}
             onChange={handleChange}
             placeholder=""
+            error={touchedFields.birthdate ? errors.birthdate : undefined}
           />
           <Button
             label="회원가입"
             type="submit"
-            disabled={mutation.isPending}
+            disabled={mutation.isPending || !isFormValid()}
           />
         </form>
         <div className="mt-4 text-center">

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -93,11 +93,20 @@ export default function SignupForm() {
           await passwordSchema.parseAsync(formData[field]);
         }
         setErrors((prev) => ({ ...prev, [field]: undefined }));
-      } catch (error: any) {
+      } catch (error) {
         if (error instanceof z.ZodError) {
+          // ZodError 처리
           setErrors((prev) => ({ ...prev, [field]: error.errors[0].message }));
+        } else if (error instanceof Error) {
+          // 일반적인 Error 처리
+          console.error("Unexpected error during validation:", error.message);
+          setErrors((prev) => ({
+            ...prev,
+            [field]: "알 수 없는 오류가 발생했습니다.",
+          }));
         } else {
-          console.error("Unexpected error during validation:", error);
+          // 예상치 못한 오류 처리
+          console.error("Unknown error type:", error);
           setErrors((prev) => ({
             ...prev,
             [field]: "알 수 없는 오류가 발생했습니다.",

--- a/src/components/common/ui/Button.tsx
+++ b/src/components/common/ui/Button.tsx
@@ -25,7 +25,15 @@ export default function Button({
     <div>
       <button
         type={type}
-        className={`${width} flex justify-center py-2 px-4 shadow-sm ${rounded} ${fontSize} ${fontWeight} text-font_btn bg-main hover:bg-sub`}
+        className={`${width} flex justify-center py-2 px-4 shadow-sm ${rounded} ${fontSize} ${fontWeight} 
+        ${
+          disabled
+            ? "bg-gray-200 text-gray-500 cursor-not-allowed"
+            : "text-font_btn bg-main hover:bg-sub"
+        }
+        transition-colors
+        duration-200
+      `}
         onClick={onClick}
         disabled={disabled}
       >

--- a/src/components/common/ui/ContentBox.tsx
+++ b/src/components/common/ui/ContentBox.tsx
@@ -12,33 +12,49 @@ interface ContentBoxProps {
   imageUrl?: string;
 }
 
+const truncateText = (text: string, maxLength: number) => {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength) + "...";
+};
+
 const ContentBox = forwardRef(function ContentBox(
   { id, title, description, scraps, comments, imageUrl }: ContentBoxProps,
   ref: ForwardedRef<HTMLAnchorElement>
 ) {
+  const truncatedTitle = truncateText(title, 15);
+  const truncatedDescription = truncateText(description, 60);
+
   return (
     <Link href={`/posts/${id}`} className="block no-underline" ref={ref}>
       <article className="bg-white rounded-lg shadow overflow-hidden">
-        <div className="p-4 flex">
-          <div className="w-24 h-24 bg-gray-200 rounded-md mr-4 overflow-hidden relative">
-            {imageUrl ? (
-              <Image
-                src={imageUrl}
-                alt={title}
-                fill
-                sizes="(max-width: 768px) 96px, 96px"
-                className="object-cover"
-                priority
-              />
-            ) : (
-              <div className="w-full h-full flex items-center justify-center text-gray-400">
-                이미지 없음
-              </div>
-            )}
-          </div>
-          <div className="flex-grow">
-            <h2 className="text-xl font-semibold mb-2">{title}</h2>
-            <p className="text-gray-600">{description}</p>
+        <div className="p-4">
+          <div className="flex gap-4">
+            <div className="flex-shrink-0 w-24 h-32 bg-gray-200 rounded-md overflow-hidden">
+              {imageUrl ? (
+                <div className="relative w-full h-full">
+                  <Image
+                    src={imageUrl}
+                    alt={truncatedTitle}
+                    width={128}
+                    height={128}
+                    className="object-cover w-full h-full"
+                    priority
+                  />
+                </div>
+              ) : (
+                <div className="w-full h-full flex items-center justify-center text-gray-400">
+                  이미지 없음
+                </div>
+              )}
+            </div>
+            <div className="flex-1 min-w-0 flex flex-col">
+              <h2 className="text-xl font-semibold mb-2" title={title}>
+                {truncatedTitle}
+              </h2>
+              <p className="text-gray-600 flex-1" title={description}>
+                {truncatedDescription}
+              </p>
+            </div>
           </div>
         </div>
         <div className="px-4 py-2 bg-gray-50 flex justify-end items-center space-x-2">

--- a/src/components/common/ui/FormInput.tsx
+++ b/src/components/common/ui/FormInput.tsx
@@ -7,6 +7,7 @@ export function FormInput({
   value,
   onChange,
   placeholder,
+  error,
   required = true,
 }: FormInputProps) {
   return (
@@ -23,6 +24,7 @@ export function FormInput({
         className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-border focus:border-border"
         required={required}
       />
+      {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
     </div>
   );
 }

--- a/src/components/common/ui/header/Header.tsx
+++ b/src/components/common/ui/header/Header.tsx
@@ -26,7 +26,9 @@ export default function Header() {
   return (
     <header className="bg-white shadow">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
-        <h1 className="text-2xl font-bold text-font_main">CAMPTA</h1>
+        <Link href={"/"}>
+          <h1 className="text-2xl font-bold text-font_main">CAMPTA</h1>
+        </Link>
         <SearchBar />
         {isClient ? (
           isLogin ? (

--- a/src/lib/auth/signup/types.ts
+++ b/src/lib/auth/signup/types.ts
@@ -31,5 +31,6 @@ export interface FormInputProps {
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   placeholder?: string;
+  error?: string | undefined;
   required?: boolean;
 }

--- a/src/lib/auth/signup/validationSchemas.ts
+++ b/src/lib/auth/signup/validationSchemas.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const emailSchema = z.string().email("올바른 이메일 형식이 아닙니다.");
+
+export const passwordSchema = z
+  .string()
+  .min(8, "비밀번호는 최소 8자 이상이어야 합니다.")
+  .regex(
+    /[!@#$%^&*(),.?":{}|<>]/,
+    "비밀번호에는 최소 1개의 특수문자가 포함되어야 합니다."
+  );
+
+export const signupSchema = z.object({
+  name: z.string().min(1, "이름을 입력해주세요."),
+  email: emailSchema,
+  password: passwordSchema,
+  nickname: z.string().min(1, "닉네임을 입력해주세요."),
+  birthdate: z.string().min(1, "생년월일을 입력해주세요."),
+  profileImg: z.string().nullable(),
+});
+
+export type SignupFormData = z.infer<typeof signupSchema>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,14 @@
     ],
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## 반영 브랜치

feat/signup-validation -> dev

## 📝 작업 내용

**회원가입 유효성 로직 구현**

- zod 라이브러리 설치
- `lib/auth/signup/validationSchemas.ts` 생성
- 이메일, 비밀번호 유효성 검사 로직 구현
- 이메일 중복 검사 로직 구현
- 닉네임 중복 검사 로직 구현, 중복확인 버튼 UI 구현
- `app/api/auth/signup/nicknameCheck/route.ts` 생성
- 모든 필드 값 입력 시에만 회원가입 버튼이 활성화되도록 수정
